### PR TITLE
Add info about installing pre-commit manager

### DIFF
--- a/{{cookiecutter.project_name}}/docs/_pages/template/development-process.rst
+++ b/{{cookiecutter.project_name}}/docs/_pages/template/development-process.rst
@@ -44,7 +44,7 @@ Configuring pre-commit
 
 We are using several pre-commit hooks to make sure everything works just fine.
 Before you can run hooks, you need to have the pre-commit package manager installed.
-See `pre-commit page <https://pre-commit.com/#install>`_ for install guide.
+It comes bundled in our project requirements (specified in Pipfile).
 To setup hooks after installing all the dependencies run:
 
 .. code:: bash

--- a/{{cookiecutter.project_name}}/docs/_pages/template/development-process.rst
+++ b/{{cookiecutter.project_name}}/docs/_pages/template/development-process.rst
@@ -43,6 +43,8 @@ Configuring pre-commit
 ~~~~~~~~~~~~~~~~~~~~~~
 
 We are using several pre-commit hooks to make sure everything works just fine.
+Before you can run hooks, you need to have the pre-commit package manager installed.
+See `pre-commit page <https://pre-commit.com/#install>`_ for install guide.
 To setup hooks after installing all the dependencies run:
 
 .. code:: bash


### PR DESCRIPTION
For first time it is unclear how to use pre-commit hooks with `.pre-commit-config.yml` file.
I added info about `pre-commit` manager package to `development-process` page, where pre-commit instructions are.
But I think, that info about manager should be earlier, like at the `dependencies` page. But on that page there is info only about `python` deps.
What do you think?