### PR TITLE
Yamllint into pre-commit-config

### DIFF
--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -12,3 +12,10 @@
       entry: docker-compose run -e INSIDE_CI=0 web sh ./docker/ci.sh
       pass_filenames: false
       language: system
+    - id: yamllint
+      name: yamllint
+      description: This hook runs yamllint.
+      entry: pipenv run yamllint .yamllint-light .
+      pass_filenames: false
+      language: system
+      types: [yaml]

--- a/{{cookiecutter.project_name}}/.yamllint-light
+++ b/{{cookiecutter.project_name}}/.yamllint-light
@@ -1,0 +1,33 @@
+extends: default
+
+rules:
+  braces:
+    level: warning
+    max-spaces-inside: 1
+  brackets:
+    level: warning
+    max-spaces-inside: 1
+  colons:
+    level: warning
+  commas:
+    level: warning
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 2
+    max-start: 0
+    max-end: 0
+  hyphens:
+    level: warning
+  indentation:
+    level: warning
+    spaces: 2
+    indent-sequences: consistent
+  line-length:
+    level: warning
+    allow-non-breakable-inline-mappings: true
+  truthy: disable
+  new-line-at-end-of-file: enable
+  line-length:
+    max: 120

--- a/{{cookiecutter.project_name}}/Pipfile
+++ b/{{cookiecutter.project_name}}/Pipfile
@@ -44,6 +44,7 @@ sphinx-autodoc-typehints = "*"
 sphinxcontrib-napoleon = "*"
 "doc8" = "*"
 bandit = "*"
+yamllint = "*"
 
 [packages]
 django = "<2.0"


### PR DESCRIPTION
Hello, Mr. @sobolevn !
I added yamllint to pre-commit. So it runs yamllint after  any changes yaml files. 
And added light version of yamllint's config .
For me, it lookes more pretty :
```
 script:
   - docker-compose -f docker-compose.yml -f docker/docker-compose.prod.yml config --quiet
```
then this variant:
```
  script:
     - docker-compose -f docker-compose.yml
       -f docker/docker-compose.prod.yml config --quiet
```
So you have some the choice
Issue #425