### PR TITLE
Should be with a capital letter

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 
 [flake8]
 max-complexity = 6
-statistics = true
+statistics = True
 max-line-length = 80
 doctests = True
 


### PR DESCRIPTION
From docs http://flake8.pycqa.org/en/latest/user/options.html?#cmdoption-flake8-statistics

Example config file usage:
```
statistics = True
```