### PR TITLE
Fixed typo in cookiecutter setup.cfg

### DIFF
--- a/{{cookiecutter.project_name}}/setup.cfg
+++ b/{{cookiecutter.project_name}}/setup.cfg
@@ -10,7 +10,7 @@ omit =
 
 [flake8]
 max-complexity = 6
-statistics = true
+statistics = True
 max-line-length = 80
 doctests = True
 


### PR DESCRIPTION
From docs http://flake8.pycqa.org/en/latest/user/options.html?#cmdoption-flake8-statistics

Example config file usage:
```
statistics = True
```