### PR TITLE
Fix path to favicon and its filename

### DIFF
--- a/{{cookiecutter.project_name}}/server/main_app/templates/main_app/index.html
+++ b/{{cookiecutter.project_name}}/server/main_app/templates/main_app/index.html
@@ -10,9 +10,9 @@
 
     <link rel="stylesheet" href="{% static 'main_app/css/index.css' %}">
 
-     <link rel="icon" type="image/png" sizes="16x16" href="{% static '/images/favicon-16x16.png' %}">
+     <link rel="icon" type="image/png" sizes="16x16" href="{% static 'images/favicon-16x16.png' %}">
 
-     <link rel="icon" type="image/png" sizes="32x32" href="{% static '/images/favicon.png-32x32' %}">
+     <link rel="icon" type="image/png" sizes="32x32" href="{% static 'images/favicon-32x32.png' %}">
 
   </head>
 


### PR DESCRIPTION
This fixes `ManifestStaticFilesStorage` failing with an error:
`ValueError: Missing staticfiles manifest entry for '/images/favicon-16x16.png'.`