### PR TITLE
fix typo

### DIFF
--- a/{{cookiecutter.project_name}}/setup.cfg
+++ b/{{cookiecutter.project_name}}/setup.cfg
@@ -23,7 +23,7 @@ isort-show-traceback = True
 ignore = D100, D104, D106, D401, X100, W504
 
 # Docs: https://github.com/snoack/flake8-per-file-ignores
-# You can completly or partialy disable our custom checks,
+# You can completely or partially disable our custom checks,
 # to do so you have to ignore `Z` letter for all python files:
 per-file-ignores =
   # Allow `__init__.py` with logic for configuration:


### PR DESCRIPTION
Side question: should we add the `migrations` folder to `per-file-ignores` as well?