### PR TITLE
Run compilemessages django command at Dockerfile, not at startup script

### DIFF
--- a/{{cookiecutter.project_name}}/docker/django/Dockerfile
+++ b/{{cookiecutter.project_name}}/docker/django/Dockerfile
@@ -71,3 +71,5 @@ ENTRYPOINT ["/sbin/tini", "--", "/docker-entrypoint.sh"]
 FROM development_build as production_build
 
 COPY . /code
+
+RUN python /code/manage.py compilemessages

--- a/{{cookiecutter.project_name}}/docker/django/gunicorn.sh
+++ b/{{cookiecutter.project_name}}/docker/django/gunicorn.sh
@@ -22,7 +22,6 @@ export DJANGO_ENV
 # docs/pages/template/production-checklist.rst
 python /code/manage.py migrate --noinput
 python /code/manage.py collectstatic --noinput
-python /code/manage.py compilemessages
 
 # Start gunicorn with 4 workers:
 /usr/local/bin/gunicorn server.wsgi \


### PR DESCRIPTION
Run command in Dockerfile after all code is copied into image.

Closes #910