### PR TITLE
Update django-axes documentation link

### DIFF
--- a/{{cookiecutter.project_name}}/server/settings/components/caches.py
+++ b/{{cookiecutter.project_name}}/server/settings/components/caches.py
@@ -14,7 +14,6 @@ CACHES = {
 
 
 # django-axes
-# https://django-axes.readthedocs.io/en/latest/configuration.html
-# See #known-configuration-problems section
+# https://django-axes.readthedocs.io/en/latest/4_configuration.html#configuring-caches
 
 AXES_CACHE = 'axes_cache'


### PR DESCRIPTION
Visiting the previous link to the django-axes documentation results in a 404 Not Found page.

https://django-axes.readthedocs.io/en/latest/configuration.html

As of django-axes v5.0, the documentation stopped including the **Known Configuration Problems** section as part of the reference for cache settings.

The outdated version of the documentation including the **Known Configuration Problems** section can be found here:

https://github.com/jazzband/django-axes/blob/4.1.0/docs/configuration.rst#known-configuration-problems