### PR TITLE
fixed type on last line testing.rst: what -> want

### DIFF
--- a/{{cookiecutter.project_name}}/docs/pages/template/testing.rst
+++ b/{{cookiecutter.project_name}}/docs/pages/template/testing.rst
@@ -108,4 +108,4 @@ for more information.
 We also use `django-stubs <https://github.com/typeddjango/django-stubs>`_
 to type ``django`` internals.
 This package is optional and can be removed,
-if you don't what to type your ``django`` for some reason.
+if you don't want to type your ``django`` for some reason.


### PR DESCRIPTION
There was a typo in the testing.rst file:
>> This package is optional and can be removed, if you don't **what** to type your ``django`` for some reason.
Fixed to:
>> This package is optional and can be removed, if you don't **want** to type your ``django`` for some reason.

