### PR TITLE
Fixed docs typo in production-checklist.rst: --dry-dun -> dru-run

### DIFF
--- a/{{cookiecutter.project_name}}/docker-compose.yml
+++ b/{{cookiecutter.project_name}}/docker-compose.yml
@@ -38,11 +38,15 @@ services:
         DJANGO_DATABASE_HOST: db
     command: python -Wd manage.py runserver 0.0.0.0:8000
     healthcheck:
-      test: curl --fail http://localhost:8000/health/?format=json || exit 1
-      interval: 1m
+      test: |
+        /usr/bin/test $$(
+          /usr/bin/curl --fail http://localhost:8000/health/?format=json
+          --write-out "%{http_code}" --silent --output /dev/null
+        ) -eq 200
+      interval: 10s
       timeout: 5s
-      retries: 2
-      start_period: 1m
+      retries: 5
+      start_period: 30s
 
 # This task is an example of how to extend existing ones:
 # some_worker:

--- a/{{cookiecutter.project_name}}/docs/pages/template/production-checklist.rst
+++ b/{{cookiecutter.project_name}}/docs/pages/template/production-checklist.rst
@@ -38,7 +38,7 @@ We also check that static files can be collected:
 
 However, this check does not cover all the cases.
 Sometimes ``ManifestStaticFilesStorage`` will fail on real cases,
-but will pass with ``--dry-dun`` option.
+but will pass with ``--dry-run`` option.
 You can disable ``--dry-run`` option if you know what you are doing.
 Be careful with this option, when working with auto-uploading
 your static files to any kind of CDNs.

--- a/{{cookiecutter.project_name}}/docs/pages/template/testing.rst
+++ b/{{cookiecutter.project_name}}/docs/pages/template/testing.rst
@@ -108,4 +108,4 @@ for more information.
 We also use `django-stubs <https://github.com/typeddjango/django-stubs>`_
 to type ``django`` internals.
 This package is optional and can be removed,
-if you don't what to type your ``django`` for some reason.
+if you don't want to type your ``django`` for some reason.


### PR DESCRIPTION
Fixed docs typo in production-checklist.rst
>> but will pass with ``--dry-dun`` option
Fixed to:
>> but will pass with ``--dry-run`` option.