### PR TITLE
Fix django-debug-toolbar by adding connect-src CSP directive in dev settings

### DIFF
--- a/{{cookiecutter.project_name}}/server/settings/environments/development.py
+++ b/{{cookiecutter.project_name}}/server/settings/environments/development.py
@@ -66,6 +66,7 @@ DEBUG_TOOLBAR_CONFIG = {
 # since `ddt` loads some scripts from `ajax.googleapis.com`:
 CSP_SCRIPT_SRC = ("'self'", 'ajax.googleapis.com')
 CSP_IMG_SRC = ("'self'", 'data:')
+CSP_CONNECT_SRC = ("'self'",)
 
 
 # nplusone


### PR DESCRIPTION
<img width="736" alt="Screenshot 2020-04-02 at 15 45 05" src="https://user-images.githubusercontent.com/9629796/78262774-f5a27e80-74f8-11ea-8daf-8ffb6e1b5e04.png">

django-debug-toolbar wouldn't work without this directive. Adding `CSP_CONNECT_SRC = ("'self'",)` solved the issue.