### PR TITLE
Caddy v2

### DIFF
--- a/{{cookiecutter.project_name}}/docker/caddy/Caddyfile
+++ b/{{cookiecutter.project_name}}/docker/caddy/Caddyfile
@@ -1,31 +1,40 @@
 # See https://caddyserver.com/docs
 
+# Email for Let's Encrypt expiration notices
+{
+  email {$TLS_EMAIL}
+}
+
 # "www" redirect to "non-www" version
 www.{$DOMAIN_NAME} {
-  redir https://{$DOMAIN_NAME}
+  redir https://{$DOMAIN_NAME}{uri}
 }
 
 {$DOMAIN_NAME} {
   # HTTPS options:
-  tls {$TLS_EMAIL}
-  header / Strict-Transport-Security "max-age=31536000;"
+  header Strict-Transport-Security max-age=31536000;
 
   # Removing some headers for improved security:
-  header / -Server
+  header -Server
 
-  # Serves static files, should be the same as `STATIC_ROOT` setting:
-  root /var/www/django
-
-  # Serving dynamic requests:
-  proxy / web:8000 {
-    except /static /media
-    transparent
+  # Exclude matcher for Django assets
+  @excludeDirs {
+    not path /static/* /media/*
   }
 
-  # Allows to use `.gz` files when available:
-  gzip
+  # Serving dynamic requests:
+  reverse_proxy @excludeDirs web:8000
+
+  # Serves static files, should be the same as `STATIC_ROOT` setting:
+  file_server {
+    root /var/www/django
+  }
+
+   # Allows to use `.gz` files when available:
+  encode gzip
 
   # Logs:
-  log stdout
-  errors stdout
+  log {
+	  output stdout
+  }
 }

--- a/{{cookiecutter.project_name}}/docker/django/Dockerfile
+++ b/{{cookiecutter.project_name}}/docker/django/Dockerfile
@@ -30,13 +30,13 @@ ENV DJANGO_ENV=${DJANGO_ENV} \
 # System deps:
 RUN apt-get update \
   && apt-get install --no-install-recommends -y \
-    bash \
-    build-essential \
-    curl \
-    gettext \
-    git \
-    libpq-dev \
-    wget \
+  bash \
+  build-essential \
+  curl \
+  gettext \
+  git \
+  libpq-dev \
+  wget \
   # Cleaning cache:
   && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* \
   # Installing `dockerize` utility:
@@ -59,8 +59,8 @@ COPY ./poetry.lock ./pyproject.toml /code/
 # Project initialization:
 RUN echo "$DJANGO_ENV" \
   && poetry install \
-    $(if [ "$DJANGO_ENV" = 'production' ]; then echo '--no-dev'; fi) \
-    --no-interaction --no-ansi \
+  $(if [ "$DJANGO_ENV" = 'production' ]; then echo '--no-dev'; fi) \
+  --no-interaction --no-ansi \
   # Cleaning poetry installation's cache for production:
   && if [ "$DJANGO_ENV" = 'production' ]; then rm -rf "$POETRY_CACHE_DIR"; fi
 
@@ -70,7 +70,9 @@ COPY ./docker/django/entrypoint.sh /docker-entrypoint.sh
 # Setting up proper permissions:
 RUN chmod +x '/docker-entrypoint.sh' \
   && groupadd -r web && useradd -d /code -r -g web web \
-  && chown web:web -R /code
+  && chown web:web -R /code \
+  && mkdir -p /var/www/django/static /var/www/django/media \
+  && chown web:web /var/www/django/static /var/www/django/media
 
 # Running as non-root user:
 USER web

--- a/{{cookiecutter.project_name}}/docker/django/Dockerfile
+++ b/{{cookiecutter.project_name}}/docker/django/Dockerfile
@@ -30,13 +30,13 @@ ENV DJANGO_ENV=${DJANGO_ENV} \
 # System deps:
 RUN apt-get update \
   && apt-get install --no-install-recommends -y \
-  bash \
-  build-essential \
-  curl \
-  gettext \
-  git \
-  libpq-dev \
-  wget \
+    bash \
+    build-essential \
+    curl \
+    gettext \
+    git \
+    libpq-dev \
+    wget \
   # Cleaning cache:
   && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* \
   # Installing `dockerize` utility:
@@ -59,8 +59,8 @@ COPY ./poetry.lock ./pyproject.toml /code/
 # Project initialization:
 RUN echo "$DJANGO_ENV" \
   && poetry install \
-  $(if [ "$DJANGO_ENV" = 'production' ]; then echo '--no-dev'; fi) \
-  --no-interaction --no-ansi \
+    $(if [ "$DJANGO_ENV" = 'production' ]; then echo '--no-dev'; fi) \
+    --no-interaction --no-ansi \
   # Cleaning poetry installation's cache for production:
   && if [ "$DJANGO_ENV" = 'production' ]; then rm -rf "$POETRY_CACHE_DIR"; fi
 

--- a/{{cookiecutter.project_name}}/docker/docker-compose.prod.yml
+++ b/{{cookiecutter.project_name}}/docker/docker-compose.prod.yml
@@ -9,14 +9,15 @@
 version: "3.6"
 services:
   caddy:
-    image: "wemakeservices/caddy-docker:0.10.11-1"
+    image: "caddy:2.0.0"
     restart: unless-stopped
     env_file: ./config/.env
     volumes:
-      - ./docker/caddy/certs:/root/.caddy  # saving certificates
-      - ./docker/caddy/Caddyfile:/etc/Caddyfile:ro  # configuration
-      - django-static:/var/www/django/static:ro  # serving django's statics
-      - django-media:/var/www/django/media:ro  # serving django's media
+      - ./docker/caddy/Caddyfile:/etc/caddy/Caddyfile  # configuration
+      - caddy-config:/config  # configuation autosaves
+      - caddy-data:/data  # saving certificates
+      - django-static:/var/www/django/static  # serving django's statics
+      - django-media:/var/www/django/media  # serving django's media
     ports:
       - "80:80"
       - "443:443"
@@ -49,3 +50,7 @@ services:
 #   command: python manage.py worker_process
 #   deploy:
 #     replicas: 2
+
+volumes:
+  caddy-config:
+  caddy-data:

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -34,6 +34,7 @@ gunicorn = "^20.0"
 python-decouple = "^3.3"
 bcrypt = "^3.1"
 structlog = "^20.1.0"
+typing_extensions = "^3.7.4"
 
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Fixes #36 

Here's the caddy v2 setup. I tried to match the existing configuration as much as possible.

---

However, I got caught up for a while on two different issues that we blocking (even for the unmodified master branch) and slowed me down quite a lot:

1. My poetry environment was unable to find "typing_extensions"  in *server/apps/main/models.py:5* unless I specifically added the dependency. However, it looks like `final` and `Final` will be included [in the Python 3.8 standard library](https://docs.python.org/3/library/typing.html) so I assume it will be a non-issue after moving to 3.8.

2. Both the django-media and django-static volumes were mounted as root:root with 755 permissions inside the web container, thus collectstatic would throw a permission errors. I think it was related to [this issue](https://github.com/docker/compose/issues/3270).

I changed *pyproject.toml* and *./docker/django/Dockerfile* to fix these but I could be missing something...