### PR TITLE
Remove unnecessary code for installing django_http_referrer_policy

### DIFF
--- a/{{cookiecutter.project_name}}/server/settings/components/common.py
+++ b/{{cookiecutter.project_name}}/server/settings/components/common.py
@@ -46,9 +46,6 @@ INSTALLED_APPS: Tuple[str, ...] = (
     'health_check.db',
     'health_check.cache',
     'health_check.storage',
-
-    # Third party apps
-    'django_http_referrer_policy',
 )
 
 MIDDLEWARE: Tuple[str, ...] = (


### PR DESCRIPTION
Related to https://github.com/DmytroLitvinov/django-http-referrer-policy/issues/2