### PR TITLE
Update Caddy image's tag

### DIFF
--- a/{{cookiecutter.project_name}}/docker/docker-compose.prod.yml
+++ b/{{cookiecutter.project_name}}/docker/docker-compose.prod.yml
@@ -9,7 +9,7 @@
 version: "3.6"
 services:
   caddy:
-    image: "caddy:2.0.0"
+    image: "caddy:2"
     restart: unless-stopped
     env_file: ./config/.env
     volumes:

--- a/{{cookiecutter.project_name}}/docker/docker-compose.prod.yml
+++ b/{{cookiecutter.project_name}}/docker/docker-compose.prod.yml
@@ -9,7 +9,7 @@
 version: "3.6"
 services:
   caddy:
-    image: "caddy:2"
+    image: "caddy:2.2.1"
     restart: unless-stopped
     env_file: ./config/.env
     volumes:


### PR DESCRIPTION
From [DockerHub of Caddy image](https://hub.docker.com/_/caddy) there is a shared tag **2** which we can use to use get latest stable release.

Closes #1398 
