### PR TITLE
Update .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,14 +3,16 @@
 # by Github Actions.
 workflow:
   rules:
-    - changes:
-      - .gitlab-ci.yml
-      - '{{cookiecutter.project_name}}/.gitlab-ci.yml'
-      - tests/build.sh
-      - tests/test_gitlab.sh
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event" || $CI_PIPELINE_SOURCE == "push"'
+      when: always
+      changes:
+        - .gitlab-ci.yml
+        - '{{cookiecutter.project_name}}/.gitlab-ci.yml'
+        - tests/build.sh
+        - tests/test_gitlab.sh
 
 
-# Reusing built gitlab definition:
+# Reusing existing gitlab definition:
 include:
   - local: '{{cookiecutter.project_name}}/.gitlab-ci.yml'
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@
 # by Github Actions.
 workflow:
   rules:
-    - if: '$CI_PIPELINE_SOURCE == "merge_request_event" || $CI_PIPELINE_SOURCE == "push"'
+    - if: '$CI_PIPELINE_SOURCE'
       when: always
       changes:
         - .gitlab-ci.yml


### PR DESCRIPTION
https://docs.gitlab.com/ee/ci/yaml/#workflowrules

> You can use `rules: changes` with other pipeline types, but it is not recommended because `rules: changes` always evaluates to true when there is no Git push event. Tag pipelines, scheduled pipelines, and so on do not have a Git push event associated with them. A `rules: changes` job is always added to those pipeline if there is no if: statement that limits the job to branch or merge request pipelines.