### PR TITLE
Disable persistent DB connections in development

### DIFF
--- a/{{cookiecutter.project_name}}/server/settings/environments/development.py
+++ b/{{cookiecutter.project_name}}/server/settings/environments/development.py
@@ -8,7 +8,11 @@ import logging
 from typing import List
 
 from server.settings.components import config
-from server.settings.components.common import INSTALLED_APPS, MIDDLEWARE
+from server.settings.components.common import (
+    DATABASES,
+    INSTALLED_APPS,
+    MIDDLEWARE,
+)
 
 # Setting the development status:
 
@@ -128,3 +132,7 @@ EXTRA_CHECKS = {
         'field-choices-constraint',
     ],
 }
+
+# Disable persistent DB connections
+# https://docs.djangoproject.com/en/2.2/ref/databases/#caveats
+DATABASES['default']['CONN_MAX_AGE'] = 0


### PR DESCRIPTION
Ran into an issue in our dev environment where django would eventually 500 requests with an exception `FATAL: sorry, too many clients already` from postgre. 

After a bit of sleuthing I noticed that the wemake template sets `CONN_MAX_AGE` to a non-zero value to take advantage of persisting DB connections between requests. The setting has the following behavior ([official docs](https://docs.djangoproject.com/en/2.2/ref/databases/#persistent-connections)):

- **0** (default) - preserve historical behavior, close DB connection at the end of each request
- **postive int** - persist DB for up to this many seconds between subsequent requests
- **None** - unlimited persistent connections

This is great for performance in production but the [documentation warns not to enable it in development](https://docs.djangoproject.com/en/2.2/ref/databases/#caveats). This is because the django dev server creates a new thread for each request which in turn creates a new DB connection. We started running into the situation where these open connections bumped into postgre's max connection limit.

---

I don't know if this code is how you want the fix implemented but I highly recommend disabling this setting in development.