### PR TITLE
Increase image size to 620MiB

### DIFF
--- a/tests/test_github.sh
+++ b/tests/test_github.sh
@@ -30,4 +30,4 @@ docker-compose -f docker-compose.yml \
 
 # Checking the size of final images:
 disl "${PROJECT_NAME}:dev" 950MiB
-disl "registry.gitlab.com/${PROJECT_ORGANIZATION}/${PROJECT_NAME}:latest" 610MiB
+disl "registry.gitlab.com/${PROJECT_ORGANIZATION}/${PROJECT_NAME}:latest" 620MiB


### PR DESCRIPTION
After merging it, we can run again MRs https://github.com/wemake-services/wemake-django-template/pull/1635 and https://github.com/wemake-services/wemake-django-template/pull/1634/