### PR TITLE
Use Path instead of PurePath in Django settings

### DIFF
--- a/{{cookiecutter.project_name}}/server/settings/components/__init__.py
+++ b/{{cookiecutter.project_name}}/server/settings/components/__init__.py
@@ -1,10 +1,10 @@
-from pathlib import PurePath
+from pathlib import Path
 
 from decouple import AutoConfig
 
 # Build paths inside the project like this: BASE_DIR.joinpath('some')
 # `pathlib` is better than writing: dirname(dirname(dirname(__file__)))
-BASE_DIR = PurePath(__file__).parent.parent.parent.parent
+BASE_DIR = Path(__file__).parent.parent.parent.parent
 
 # Loading `.env` files
 # See docs: https://gitlab.com/mkleehammer/autoconfig


### PR DESCRIPTION
So, we use this template as a starting point, but most of our use cases need Django 3, so we are running a bit ahead in versions.

A security fix in the latest release (v3.2.4) causes an exception to be raised when settings are loaded. It seems that Django starts using functionality in `Path` that is not available in `PurePath` when doing some filesystem operations. I suspect that the back-ported fix (v2.2.24) could also introduce this same problem.

The response to my Django support ticket suggests that `PurePath` in Django settings is bad practice in general: https://code.djangoproject.com/ticket/32887