### PR TITLE
urls.py cleanup

### DIFF
--- a/{{cookiecutter.project_name}}/server/urls.py
+++ b/{{cookiecutter.project_name}}/server/urls.py
@@ -53,8 +53,7 @@ if settings.DEBUG:  # pragma: no cover
     urlpatterns = [
         # URLs specific only to django-debug-toolbar:
         path('__debug__/', include(debug_toolbar.urls)),  # noqa: DJ05
-    ] + urlpatterns + static(  # type: ignore
+        *urlpatterns,
         # Serving media files in development only:
-        settings.MEDIA_URL,
-        document_root=settings.MEDIA_ROOT,
-    )
+        *static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT),
+    ]

--- a/{{cookiecutter.project_name}}/server/urls.py
+++ b/{{cookiecutter.project_name}}/server/urls.py
@@ -26,10 +26,10 @@ urlpatterns = [
     path('main/', include(main_urls, namespace='main')),
 
     # Health checks:
-    path('health/', include(health_urls)),  # noqa: DJ05
+    path('health/', include(health_urls)),
 
     # django-admin:
-    path('admin/doc/', include(admindocs_urls)),  # noqa: DJ05
+    path('admin/doc/', include(admindocs_urls)),
     path('admin/', admin.site.urls),
 
     # Text and xml static files:
@@ -52,7 +52,7 @@ if settings.DEBUG:  # pragma: no cover
 
     urlpatterns = [
         # URLs specific only to django-debug-toolbar:
-        path('__debug__/', include(debug_toolbar.urls)),  # noqa: DJ05
+        path('__debug__/', include(debug_toolbar.urls)),
         *urlpatterns,
         # Serving media files in development only:
         *static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT),


### PR DESCRIPTION
- Use asterisk to combine URLs lists. IMO it is more readable. It also fixes the typing error.
- Remove `noqa: DJ05` comments. This rule [was removed almost 2 years ago](https://github.com/rocioar/flake8-django/commit/9590fd70c7b2e8dd7ba00bd5531b24ff07e49739).