### PR TITLE
Set `PASSWORD_HASHERS` to the value from docs

### DIFF
--- a/{{cookiecutter.project_name}}/server/settings/components/common.py
+++ b/{{cookiecutter.project_name}}/server/settings/components/common.py
@@ -171,10 +171,10 @@ AUTHENTICATION_BACKENDS = (
 
 PASSWORD_HASHERS = [
     'django.contrib.auth.hashers.BCryptSHA256PasswordHasher',
-    'django.contrib.auth.hashers.BCryptPasswordHasher',
     'django.contrib.auth.hashers.PBKDF2PasswordHasher',
     'django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher',
     'django.contrib.auth.hashers.Argon2PasswordHasher',
+    'django.contrib.auth.hashers.ScryptPasswordHasher',
 ]
 
 


### PR DESCRIPTION
See https://docs.djangoproject.com/en/4.0/topics/auth/passwords/#using-bcrypt-with-django.

`django.contrib.auth.hashers.BCryptPasswordHasher` has been missing from this list since Django 2.1.

`django.contrib.auth.hashers.ScryptPasswordHasher` is enabled by default since Django 4.0.

I would also like to suggest using `Argon2` instead of `bcrypt` by default because it is the winner of the [password hashing competition](https://www.password-hashing.net/), and [OWASP also recommends Argon2 over bcrypt](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#bcrypt). I can make a separate pull request for this, or edit the current one.