### PR TITLE
Precompress static files with Brotli and gzip

### DIFF
--- a/{{cookiecutter.project_name}}/docker/caddy/Caddyfile
+++ b/{{cookiecutter.project_name}}/docker/caddy/Caddyfile
@@ -17,20 +17,32 @@ www.{$DOMAIN_NAME} {
 	# Removing some headers for improved security:
 	header -Server
 
-	# Exclude matcher for Django assets
-	@excludeDirs {
-		not path /static/* /media/*
+	# Serve static files
+	handle_path /static/* {
+		# STATIC_ROOT
+		root * /var/www/django/static
+
+		file_server {
+			# Staticfiles are pre-compressed in `gunicorn.sh`
+			precompressed br gzip
+		}
 	}
 
-	# Serving dynamic requests:
-	reverse_proxy @excludeDirs web:8000
+	# Serve media files
+	handle_path /media/* {
+		# MEDIA_ROOT
+		root * /var/www/django/media
 
-	# Serves static files, should be the same as `STATIC_ROOT` setting:
-	file_server {
-		root /var/www/django
+		file_server
 	}
 
-	# Allows to use `.gz` files when available:
+	# Serve Django app
+	handle {
+		reverse_proxy web:8000
+	}
+
+	# Dynamically compress response with gzip when it makes sense.
+	# This setting is ignored for precompressed files.
 	encode gzip
 
 	# Logs:

--- a/{{cookiecutter.project_name}}/docker/django/Dockerfile
+++ b/{{cookiecutter.project_name}}/docker/django/Dockerfile
@@ -42,6 +42,7 @@ SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
 RUN apt-get update && apt-get upgrade -y \
   && apt-get install --no-install-recommends -y \
     bash \
+    brotli \
     build-essential \
     curl \
     gettext \

--- a/{{cookiecutter.project_name}}/docker/django/gunicorn.sh
+++ b/{{cookiecutter.project_name}}/docker/django/gunicorn.sh
@@ -22,8 +22,15 @@ export DJANGO_ENV
 # Running migrations in startup script might not be the best option, see:
 # docs/pages/template/production-checklist.rst
 python /code/manage.py migrate --noinput
-python /code/manage.py collectstatic --noinput
+python /code/manage.py collectstatic --noinput --clear
 python /code/manage.py compilemessages
+
+# Precompress static files with brotli and gzip.
+# The list of ignored file types was taken from https://github.com/evansd/whitenoise
+find /var/www/django/static -type f \
+  ! -regex '^.+\.\(jpg\|jpeg\|png\|gif\|webp\|zip\|gz\|tgz\|bz2\|tbz\|xz\|br\|swf\|flv\|woff\|woff2\)$' \
+  -exec brotli --force --best {} \+ \
+  -exec gzip --force --keep --best {} \+
 
 # Start gunicorn:
 # Docs: http://docs.gunicorn.org/en/stable/settings.html


### PR DESCRIPTION
At the moment, static files are recompressed on each request. Instead, we can pre-compress them, thus saving computational power in runtime. It also allows us to compress static files not only with gzip, but also with the more efficient Brotli algorithm.