### PR TITLE
Add more extensions to precompression ignore list

### DIFF
--- a/{{cookiecutter.project_name}}/docker/django/gunicorn.sh
+++ b/{{cookiecutter.project_name}}/docker/django/gunicorn.sh
@@ -28,7 +28,7 @@ python /code/manage.py compilemessages
 # Precompress static files with brotli and gzip.
 # The list of ignored file types was taken from https://github.com/evansd/whitenoise
 find /var/www/django/static -type f \
-  ! -regex '^.+\.\(jpg\|jpeg\|png\|gif\|webp\|zip\|gz\|tgz\|bz2\|tbz\|xz\|br\|swf\|flv\|woff\|woff2\)$' \
+  ! -regex '^.+\.\(jpg\|jpeg\|png\|gif\|webp\|zip\|gz\|tgz\|bz2\|tbz\|xz\|br\|swf\|flv\|woff\|woff2\|3gp\|3gpp\|asf\|avi\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|wmv\)$' \
   -exec brotli --force --best {} \+ \
   -exec gzip --force --keep --best {} \+
 


### PR DESCRIPTION
The precompression ignore list [has been updated in WhiteNoise](https://github.com/evansd/whitenoise/commit/612ab31f4c4b504eec4c1b4ce89f27fbf58824f2).