### PR TITLE
Fix pytest deprecation warnings

### DIFF
--- a/tests/test_project_generation.py
+++ b/tests/test_project_generation.py
@@ -50,14 +50,14 @@ def test_with_default_configuration(cookies, context):
 
     assert baked_project.exit_code == 0
     assert baked_project.exception is None
-    assert baked_project.project.basename == context['project_name']
-    assert baked_project.project.isdir()
+    assert baked_project.project_path.name == context['project_name']
+    assert baked_project.project_path.is_dir()
 
 
 def test_variables_replaced(cookies, context):
     """Ensures that all variables are replaced inside project files."""
     baked_project = cookies.bake(extra_context=context)
-    paths = build_files_list(str(baked_project.project))
+    paths = build_files_list(str(baked_project.project_path))
 
     assert_variables_replaced(paths)
 
@@ -65,7 +65,7 @@ def test_variables_replaced(cookies, context):
 def test_pyproject_toml(cookies, context):
     """Ensures that all variables are replaced inside project files."""
     baked_project = cookies.bake(extra_context=context)
-    path = os.path.join(str(baked_project.project), 'pyproject.toml')
+    path = os.path.join(str(baked_project.project_path), 'pyproject.toml')
 
     with open(path, mode='rb') as pyproject:
         poetry = tomli.load(pyproject)['tool']['poetry']


### PR DESCRIPTION
Fix the following warnings:

```
tests/test_project_generation.py::test_with_default_configuration                               
tests/test_project_generation.py::test_with_default_configuration                                                                                                                               
tests/test_project_generation.py::test_pyproject_toml                                           
tests/test_project_generation.py::test_variables_replaced                                                                                                                                       
  /home/incred/.cache/pypoetry/virtualenvs/wemake-django-template-C36NRCbl-py3.10/lib/python3.10/site-packages/pytest_cookies/plugin.py:36: DeprecationWarning: project is deprecated and will b
e removed in a future release, please use project_path instead.                                 
    warnings.warn(  
```