### PR TITLE
Fix windows line separator problem

### DIFF
--- a/{{cookiecutter.project_name}}/docker/django/Dockerfile
+++ b/{{cookiecutter.project_name}}/docker/django/Dockerfile
@@ -92,6 +92,9 @@ COPY ./docker/django/entrypoint.sh /docker-entrypoint.sh
 # Setting up proper permissions:
 RUN chmod +x '/docker-entrypoint.sh'
 
+# Replacing line separator CRLF with LF for Windows users:
+RUN sed -i 's/\r$//g' '/docker-entrypoint.sh'
+
 # Running as non-root user:
 USER web
 

--- a/{{cookiecutter.project_name}}/docker/django/Dockerfile
+++ b/{{cookiecutter.project_name}}/docker/django/Dockerfile
@@ -90,10 +90,9 @@ RUN --mount=type=cache,target="$POETRY_CACHE_DIR" \
 COPY ./docker/django/entrypoint.sh /docker-entrypoint.sh
 
 # Setting up proper permissions:
-RUN chmod +x '/docker-entrypoint.sh'
-
-# Replacing line separator CRLF with LF for Windows users:
-RUN sed -i 's/\r$//g' '/docker-entrypoint.sh'
+RUN chmod +x '/docker-entrypoint.sh' \
+  # Replacing line separator CRLF with LF for Windows users:
+  && sed -i 's/\r$//g' '/docker-entrypoint.sh'
 
 # Running as non-root user:
 USER web


### PR DESCRIPTION
Hey @sobolevn.
This automatically fixes the "/usr/bin/env: 'bash\r': No such file or directory" error when the project is run locally in docker on Windows. 

SoF discussion: https://stackoverflow.com/questions/29045140/env-bash-r-no-such-file-or-directory/29045187#29045187