### PR TITLE
Rename 'sql' directory to 'scripts'

### DIFF
--- a/{{cookiecutter.project_name}}/docs/pages/template/development.rst
+++ b/{{cookiecutter.project_name}}/docs/pages/template/development.rst
@@ -144,7 +144,7 @@ To create new development database run
 
 .. code:: bash
 
-  psql postgres -U postgres -f sql/create_database.sql
+  psql postgres -U postgres -f scripts/create_dev_database.sql
 
 Then migrate your database:
 

--- a/{{cookiecutter.project_name}}/docs/pages/template/overview.rst
+++ b/{{cookiecutter.project_name}}/docs/pages/template/overview.rst
@@ -52,7 +52,7 @@ root project
 - ``setup.cfg`` - configuration file, that is used by all tools in this project
 - ``locale/`` - helper folder, that is used to store locale data,
   empty by default
-- ``sql/`` - helper folder, that contains ``sql`` script for database setup
+- ``scripts/`` - helper folder, that contains ``sql`` script for database setup
   and teardown for local development
 
 server


### PR DESCRIPTION
Updates documentation with the correct directory name
Closes https://github.com/wemake-services/wemake-django-template/issues/2116