### PR TITLE
Avoid compiling Python when building documentation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,9 +17,6 @@ build:
   jobs:
     # See https://github.com/readthedocs/readthedocs.org/issues/4912
     pre_create_environment:
-      # Select Python version (keep in sync with other versions):
-      - asdf install python 3.9.16
-      - asdf global python 3.9.16
       - python -m pip install --upgrade --no-cache-dir virtualenv
 
       # Install poetry:

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["{{ cookiecutter.project_domain }}"]
 
 
 [tool.poetry.dependencies]
-python = "3.9.16"
+python = "3.9.17"
 
 django = { version = "^4.2", extras = ["argon2"] }
 django-split-settings = "^1.2"


### PR DESCRIPTION
Each time the documentation is built, the Python version is compiled, which takes several minutes.

I recommend you to avoid compiling that particular PATCH Python version and stick with the 3.9 provided by Read the Docs (that's already compiled).

The current Python 3.9 version exposed by Read the Docs is `3.9.17`

This will make your builds fast and reduce the CPU usage on Read the Docs as well.