### PR TITLE
Fix logger settings

### DIFF
--- a/{{cookiecutter.project_name}}/server/settings/components/logging.py
+++ b/{{cookiecutter.project_name}}/server/settings/components/logging.py
@@ -29,6 +29,11 @@ LOGGING = {
             'processor': structlog.processors.KeyValueRenderer(
                 key_order=['timestamp', 'level', 'event', 'logger'],
             ),
+            'foreign_pre_chain': [
+                structlog.stdlib.add_log_level,
+                structlog.stdlib.add_logger_name,
+                structlog.processors.TimeStamper(fmt='iso'),
+            ],
         },
     },
 


### PR DESCRIPTION
Add the log level, a logger name and a timestamp to the event_dict if the log entry is not from structlog
https://www.structlog.org/en/stable/standard-library.html#rendering-using-structlog-based-formatters-within-logging

Console log before fix:
> timestamp=**None** level=**None** event='"GET /health/?format=json HTTP/1.1" 200 111' logger=**None**

After fix:

> timestamp=**'2023-09-27T08:24:56.094167Z'** level=**'info'** event='"GET /health/?format=json HTTP/1.1" 200 111' logger=**'django.server'**