### PR TITLE
Replace django-querycount with django-query-counter

### DIFF
--- a/{{cookiecutter.project_name}}/poetry.lock
+++ b/{{cookiecutter.project_name}}/poetry.lock
@@ -843,14 +843,18 @@ asgiref = ">=3.6"
 Django = ">=3.2"
 
 [[package]]
-name = "django-querycount"
-version = "0.8.3"
-description = "Middleware that Prints the number of DB queries to the runserver console."
+name = "django-query-counter"
+version = "0.4.0"
+description = "Debug tool to print sql queries count to the console"
 optional = false
 python-versions = "*"
 files = [
-    {file = "django-querycount-0.8.3.tar.gz", hash = "sha256:0782484e8a1bd29498fa0195a67106e47cdcc98fafe80cebb1991964077cb694"},
+    {file = "django-query-counter-0.4.0.tar.gz", hash = "sha256:0bb84eef7ae0c39034ae1d3d2fc3e419f86d115d78f5d0805cd036a8907c150c"},
+    {file = "django_query_counter-0.4.0-py3-none-any.whl", hash = "sha256:ad85e03671f7b63ed6eb126244c7bb552249901611d7765dfa975657bf586fbf"},
 ]
+
+[package.dependencies]
+tabulate = "*"
 
 [[package]]
 name = "django-split-settings"
@@ -2549,7 +2553,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -3177,6 +3180,20 @@ tests = ["freezegun (>=0.2.8)", "pretend", "pytest (>=6.0)", "pytest-asyncio (>=
 typing = ["mypy (>=1.4)", "rich", "twisted"]
 
 [[package]]
+name = "tabulate"
+version = "0.9.0"
+description = "Pretty-print tabular data"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f"},
+    {file = "tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c"},
+]
+
+[package.extras]
+widechars = ["wcwidth"]
+
+[[package]]
 name = "text-unidecode"
 version = "1.3"
 description = "The most basic Text::Unidecode port"
@@ -3514,4 +3531,4 @@ dev = ["doc8", "flake8", "flake8-import-order", "rstcheck[sphinx]", "sphinx"]
 [metadata]
 lock-version = "2.0"
 python-versions = "3.11.5"
-content-hash = "4a1782210151f1860ae434c1fe84f1701f5dcc65357c11ced81746717cd65f4d"
+content-hash = "371af00254d62a8ccaf5109a0f316ac2eddeea31fc36ddfc8c4a3ded6be58e81"

--- a/{{cookiecutter.project_name}}/poetry.lock
+++ b/{{cookiecutter.project_name}}/poetry.lock
@@ -3531,4 +3531,4 @@ dev = ["doc8", "flake8", "flake8-import-order", "rstcheck[sphinx]", "sphinx"]
 [metadata]
 lock-version = "2.0"
 python-versions = "3.11.5"
-content-hash = "371af00254d62a8ccaf5109a0f316ac2eddeea31fc36ddfc8c4a3ded6be58e81"
+content-hash = "1197041ffdac7d935b481c8cc0d51505f910fce111d623f7079a6eaa4d50877a"

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -60,7 +60,7 @@ polint = "^0.4"
 dennis = "^1.1"
 dump-env = "^1.5"
 ipython = "^8.23"
-django-query-counter = "^0.4.0"
+django-query-counter = "^0.4"
 
 [tool.poetry.group.docs]
 optional = true

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -29,7 +29,6 @@ structlog = "^24.1"
 
 [tool.poetry.group.dev.dependencies]
 django-debug-toolbar = "^4.3"
-django-querycount = "^0.8"
 django-migration-linter = "^5.1"
 django-extra-checks = "^0.14"
 nplusone = "^1.0"
@@ -61,6 +60,7 @@ polint = "^0.4"
 dennis = "^1.1"
 dump-env = "^1.5"
 ipython = "^8.23"
+django-query-counter = "^0.4.0"
 
 [tool.poetry.group.docs]
 optional = true

--- a/{{cookiecutter.project_name}}/server/settings/environments/development.py
+++ b/{{cookiecutter.project_name}}/server/settings/environments/development.py
@@ -9,8 +9,16 @@ import socket
 from typing import TYPE_CHECKING
 
 from server.settings.components import config
-from server.settings.components.common import DATABASES, INSTALLED_APPS, MIDDLEWARE
-from server.settings.components.csp import CSP_CONNECT_SRC, CSP_IMG_SRC, CSP_SCRIPT_SRC
+from server.settings.components.common import (
+    DATABASES,
+    INSTALLED_APPS,
+    MIDDLEWARE,
+)
+from server.settings.components.csp import (
+    CSP_CONNECT_SRC,
+    CSP_IMG_SRC,
+    CSP_SCRIPT_SRC,
+)
 
 if TYPE_CHECKING:
     from django.http import HttpRequest

--- a/{{cookiecutter.project_name}}/server/settings/environments/development.py
+++ b/{{cookiecutter.project_name}}/server/settings/environments/development.py
@@ -57,6 +57,7 @@ INSTALLED_APPS += (
 
     # django-extra-checks:
     'extra_checks',
+    # django-query-counter:
     'query_counter',
 )
 

--- a/{{cookiecutter.project_name}}/server/settings/environments/development.py
+++ b/{{cookiecutter.project_name}}/server/settings/environments/development.py
@@ -9,16 +9,8 @@ import socket
 from typing import TYPE_CHECKING
 
 from server.settings.components import config
-from server.settings.components.common import (
-    DATABASES,
-    INSTALLED_APPS,
-    MIDDLEWARE,
-)
-from server.settings.components.csp import (
-    CSP_CONNECT_SRC,
-    CSP_IMG_SRC,
-    CSP_SCRIPT_SRC,
-)
+from server.settings.components.common import DATABASES, INSTALLED_APPS, MIDDLEWARE
+from server.settings.components.csp import CSP_CONNECT_SRC, CSP_IMG_SRC, CSP_SCRIPT_SRC
 
 if TYPE_CHECKING:
     from django.http import HttpRequest
@@ -57,6 +49,7 @@ INSTALLED_APPS += (
 
     # django-extra-checks:
     'extra_checks',
+    'query_counter',
 )
 
 
@@ -66,9 +59,9 @@ INSTALLED_APPS += (
 MIDDLEWARE += (
     'debug_toolbar.middleware.DebugToolbarMiddleware',
 
-    # https://github.com/bradmontgomery/django-querycount
+    # https://github.com/conformist-mw/django-query-counter
     # Prints how many queries were executed, useful for the APIs.
-    'querycount.middleware.QueryCountMiddleware',
+    'query_counter.middleware.DjangoQueryCounterMiddleware',
 )
 
 # https://django-debug-toolbar.readthedocs.io/en/stable/installation.html#configure-internal-ips


### PR DESCRIPTION
Replaced django-querycount with supported django-query-counter.

Reasons:

1. When adding wagtail to the project in development mode, the preview feature does not work out of the box.
2. The package is newer and performs similar functions.