### PR TITLE
Remove diff from ruff check

### DIFF
--- a/{{cookiecutter.project_name}}/docker/django/ci.sh
+++ b/{{cookiecutter.project_name}}/docker/django/ci.sh
@@ -34,7 +34,7 @@ run_ci () {
   dotenv-linter config/.env config/.env.template
 
   # Running linting for all python files in the project:
-  ruff check --exit-non-zero-on-fix --diff
+  ruff check --exit-non-zero-on-fix
   ruff format --check --diff
   flake8 .
 


### PR DESCRIPTION
Remove --diff from ruff check. 

This is necessary because the `--diff` setting does not return the error key if there is nothing to fix.