### PR TITLE
Consolidate cors config.

### DIFF
--- a/{{cookiecutter.project_name}}/server/settings/components/api.py
+++ b/{{cookiecutter.project_name}}/server/settings/components/api.py
@@ -34,5 +34,7 @@ DMR_SETTINGS: Any = {
 
 CORS_ALLOWED_ORIGINS = [
     f'https://{config("DOMAIN_NAME")}',
+    f'https://{config("FRONTEND_URL", default="localhost:3000")}',
 ]
 CORS_ALLOW_ALL_ORIGINS = False
+CORS_ALLOWED_CREDENTIALS = True

--- a/{{cookiecutter.project_name}}/server/settings/components/common.py
+++ b/{{cookiecutter.project_name}}/server/settings/components/common.py
@@ -93,13 +93,6 @@ DATABASES = {
 # https://docs.djangoproject.com/en/6.0/ref/settings/#default-auto-field
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
-# Cors headers Settings
-CORS_ALLOWED_ORIGINS = [
-    config('FRONTEND_URL', default='http://localhost:3000'),
-]
-
-CORS_ALLOWED_CREDENTIALS = True
-
 # Internationalization
 # https://docs.djangoproject.com/en/6.0/topics/i18n/
 


### PR DESCRIPTION
Closes #3084 

Moved `CORS_ALLOWED_ORIGINS` and `CORS_ALLOWED_CREDENTIALS` from `common.py` to `api.py`
